### PR TITLE
Remove a non-existent Node.js list

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Feel free to add new lists or categories! Remember, it's not mandatory that name
 
 ## Node.js
 
-* [Awesome Node.js (vndmtrx)](https://github.com/vndmtrx/awesome-nodejs) - A curated list of astonishing Node.js frameworks, libraries and resources
 * [Awesome Node.js (sindresorhus)](https://github.com/sindresorhus/awesome-nodejs) - A curated list of delightful Node.js packages and resources
 
 ## React


### PR DESCRIPTION
Currently there's one Node.js list that got deleted and it returns 404 because of that. It should be removed from the list.